### PR TITLE
Feat/add missing functionalities

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ Then, run the installer:
 rails generate power_client:install
 ```
 
+This will:
+- Install [`active_job_log`](https://github.com/platanus/active_job_log) gem, which generates the `ActiveJobLog::Job` model
+- Create a new `ClientJob` model, which will have the responsablity of saving error screenshots using Shrine. This model has a 1-1 relation with `ActiveJobLog::Job` model, so please add the following lines to this last model:
+
+```ruby
+    has_one :client_job,
+      foreign_key: 'active_job_log_job_id', required: false, dependent: :destroy,
+      inverse_of: :active_job_log_job
+```
+
+- Create the file `app/uploaders/image_uploader.rb`
+
 ## Usage
 
 ### Creating new clients

--- a/app/models/active_job_log/job.rb
+++ b/app/models/active_job_log/job.rb
@@ -1,0 +1,36 @@
+module ActiveJobLog
+  class Job < ApplicationRecord
+    include Loggeable
+
+    has_one :client_job,
+      foreign_key: 'active_job_log_job_id', required: false, dependent: :destroy,
+      inverse_of: :active_job_log_job
+  end
+end
+
+# == Schema Information
+#
+# Table name: active_job_log_jobs
+#
+#  id                 :bigint(8)        not null, primary key
+#  job_id             :string
+#  params             :text
+#  status             :string
+#  job_class          :string
+#  error              :text
+#  stack_trace        :text
+#  queued_at          :datetime
+#  started_at         :datetime
+#  ended_at           :datetime
+#  queued_duration    :integer
+#  execution_duration :integer
+#  total_duration     :integer
+#  executions         :integer
+#  queue_name         :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#
+# Indexes
+#
+#  index_active_job_log_jobs_on_job_id  (job_id)
+#

--- a/db/migrate/20200401201119_create_client_job.rb
+++ b/db/migrate/20200401201119_create_client_job.rb
@@ -1,0 +1,10 @@
+class CreateClientJob < ActiveRecord::Migration[5.2]
+  def change
+    create_table :client_jobs do |t|
+      t.text :screenshot_file_data
+      t.references :active_job_log_job, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/lib/generators/power_client/install/install_generator.rb
+++ b/lib/generators/power_client/install/install_generator.rb
@@ -1,9 +1,23 @@
 class PowerClient::InstallGenerator < Rails::Generators::Base
   source_root File.expand_path('templates', __dir__)
 
-  desc "This generator installs active_job_log gem"
+  desc "This generator installs active_job_log gem and generates basic models needed"
 
   def install_active_job_log
     generate "active_job_log:install"
+  end
+
+  def copy_engine_migrations
+    rake "railties:install:migrations"
+  end
+
+  def create_job_model
+    create_file(helper.job_model_path, helper.job_model_tpl)
+  end
+
+  private
+
+  def helper
+    @helper ||= PowerClient::GeneratorHelpers.new
   end
 end

--- a/lib/generators/power_client/install/install_generator.rb
+++ b/lib/generators/power_client/install/install_generator.rb
@@ -15,6 +15,10 @@ class PowerClient::InstallGenerator < Rails::Generators::Base
     create_file(helper.job_model_path, helper.job_model_tpl)
   end
 
+  def create_shrine_uploader
+    create_file(helper.uploader_path, helper.uploader_tpl)
+  end
+
   private
 
   def helper

--- a/lib/power_client/engine.rb
+++ b/lib/power_client/engine.rb
@@ -13,6 +13,7 @@ module PowerClient
       require_relative "./errors"
       require_relative "./generator_helper/client_helper"
       require_relative "./generator_helper/job_helper"
+      require_relative "./generator_helper/job_model_helper"
       require_relative "./generator_helper/name_helper"
       require_relative "./generator_helper/parser_helper"
       require_relative "./generator_helper/rspec_helper"

--- a/lib/power_client/engine.rb
+++ b/lib/power_client/engine.rb
@@ -17,6 +17,7 @@ module PowerClient
       require_relative "./generator_helper/name_helper"
       require_relative "./generator_helper/parser_helper"
       require_relative "./generator_helper/rspec_helper"
+      require_relative "./generator_helper/shrine_helper"
       require_relative "./generator_helpers"
     end
   end

--- a/lib/power_client/generator_helper/job_model_helper.rb
+++ b/lib/power_client/generator_helper/job_model_helper.rb
@@ -1,0 +1,17 @@
+module PowerClient::GeneratorHelper::JobModelHelper
+  extend ActiveSupport::Concern
+
+  def job_model_path
+    'app/models/client_job.rb'
+  end
+
+  def job_model_tpl
+    <<~MODEL
+      class ClientJob < ApplicationRecord
+        include ImageUploader::Attachment(:screenshot_file)
+
+        belongs_to :active_job_log_job, class_name: 'ActiveJobLog::Job'
+      end
+    MODEL
+  end
+end

--- a/lib/power_client/generator_helper/shrine_helper.rb
+++ b/lib/power_client/generator_helper/shrine_helper.rb
@@ -1,0 +1,14 @@
+module PowerClient::GeneratorHelper::ShrineHelper
+  extend ActiveSupport::Concern
+
+  def uploader_path
+    'app/uploaders/image_uploader.rb'
+  end
+
+  def uploader_tpl
+    <<~UPLOADER
+      class ImageUploader < Shrine
+      end
+    UPLOADER
+  end
+end

--- a/lib/power_client/generator_helpers.rb
+++ b/lib/power_client/generator_helpers.rb
@@ -2,9 +2,11 @@ module PowerClient
   class GeneratorHelpers
     include GeneratorHelper::ClientHelper
     include GeneratorHelper::JobHelper
+    include GeneratorHelper::JobModelHelper
     include GeneratorHelper::NameHelper
     include GeneratorHelper::ParserHelper
     include GeneratorHelper::RSpecHelper
+    include GeneratorHelper::ShrineHelper
 
     def initialize(config = {})
       config.each do |attribute, value|


### PR DESCRIPTION
## Descripción
El primer PR #1 creó la estructura básica. Lo que hace este PR es añadir la funcionalidad para que los jobs queden registrados usando `active_job_logs`.

Por ahora se dejó por default que use Shrine para subir los screenshots del scraper.

### Cambios
- Se agrega un modelo `ActiveJobLog::Job` con la lógica para poder logearlo. Al instalar la gema se agrega un modelo `ClientJob`. Todos los jobs deben heredar de este último
- Se agrega un `uploader` para que se suban los screenschoots usando Shrine.